### PR TITLE
Add role_type=Client to TutorCruncher terms links on enquiry forms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,13 @@ jobs:
       DATABASE_URL: 'postgres://postgres:postgres@127.0.0.1:5432/socket_test'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: set up python
-      uses: actions/setup-python@v1
+      # ubuntu-latest is now 24.04 and no longer ships Python 3.9, and setup-python@v1 can only use
+      # versions already on the runner - so every job died here before running any tests. v5
+      # downloads 3.9.21 instead. Bumped in this PR because CI couldn't run this PR otherwise.
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9.21'
 
@@ -68,7 +71,7 @@ jobs:
       HEROKU_APP: tc-socket
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: git fetch --unshallow
       - run: git switch master
       - run: git remote add heroku https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP.git

--- a/tcsocket/app/views/company.py
+++ b/tcsocket/app/views/company.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -127,6 +129,37 @@ async def company_list(request):
     return json_response(request, list_=results)
 
 
+TC_TERMS_PATH = '/view-branch-terms/'
+TC_TERMS_ROLE_TYPE = 'Client'
+
+
+def add_terms_link_role_type(terms_link: Optional[str]) -> Optional[str]:
+    """
+    Add role_type=Client to a TutorCruncher terms link that doesn't have it.
+
+    TutorCruncher's terms page decides which audience's terms to show from a role_type query
+    parameter. Enquiry forms are Client enquiries - TutorCruncher records the ticked box as Client
+    consent - so Client is the right audience. terms_link values stored before TutorCruncher split
+    its terms per audience have no role_type and resolve to nothing, so the link opens an empty
+    page. Adding the parameter as we serve the options means every embedded form gets working
+    terms, whatever version of the frontend the page loads.
+
+    TutorCruncher now adds role_type itself when an integration is saved, so links that already
+    have one are left alone and this becomes a no-op once the stored values are all updated.
+    """
+    if not terms_link:
+        return terms_link
+    parts = urlsplit(terms_link)
+    if TC_TERMS_PATH not in parts.path:
+        # a link to the company's own terms page rather than TutorCruncher's - not ours to change
+        return terms_link
+    query = parse_qs(parts.query)
+    if 'role_type' in query:
+        return terms_link
+    query['role_type'] = [TC_TERMS_ROLE_TYPE]
+    return urlunsplit(parts._replace(query=urlencode(query, doseq=True)))
+
+
 async def company_options(request):
     """
     Get a companies options
@@ -134,4 +167,6 @@ async def company_options(request):
     opts = CompanyOptionsModel(
         name=request['company'].name, name_display=request['company'].name_display, **(request['company'].options or {})
     )
-    return json_response(request, **opts.dict())
+    data = opts.dict()
+    data['terms_link'] = add_terms_link_role_type(data['terms_link'])
+    return json_response(request, **data)

--- a/tests/test_set_company.py
+++ b/tests/test_set_company.py
@@ -558,3 +558,54 @@ async def test_update_company_update_contractors_true(cli, db_conn, company, oth
         'distance_units': 'km',
         'currency': {'code': 'USD', 'symbol': '$'},
     } == await r.json()
+
+
+async def test_options_terms_link_gets_role_type(cli, db_conn, company):
+    """A terms link stored before TutorCruncher split its terms per audience gets role_type=Client."""
+    await db_conn.execute(
+        sa_companies.update().values(options={'terms_link': 'https://app.example.com/view-branch-terms/3492/'})
+    )
+    r = await cli.get(f'/{company.public_key}/options')
+    assert r.status == 200, await r.text()
+    assert (await r.json())['terms_link'] == 'https://app.example.com/view-branch-terms/3492/?role_type=Client'
+
+
+async def test_options_terms_link_keeps_existing_role_type(cli, db_conn, company):
+    """A link TutorCruncher already stamped with an audience is left exactly as it is."""
+    await db_conn.execute(
+        sa_companies.update().values(
+            options={'terms_link': 'https://app.example.com/view-branch-terms/3492/?role_type=Contractor'}
+        )
+    )
+    r = await cli.get(f'/{company.public_key}/options')
+    assert r.status == 200, await r.text()
+    assert (await r.json())['terms_link'] == 'https://app.example.com/view-branch-terms/3492/?role_type=Contractor'
+
+
+async def test_options_terms_link_keeps_other_query_params(cli, db_conn, company):
+    """Existing query parameters survive the rewrite."""
+    await db_conn.execute(
+        sa_companies.update().values(
+            options={'terms_link': 'https://app.example.com/view-branch-terms/3492/?next=%2Fdashboard'}
+        )
+    )
+    r = await cli.get(f'/{company.public_key}/options')
+    assert r.status == 200, await r.text()
+    assert (await r.json())['terms_link'] == (
+        'https://app.example.com/view-branch-terms/3492/?next=%2Fdashboard&role_type=Client'
+    )
+
+
+async def test_options_terms_link_leaves_own_terms_page_alone(cli, db_conn, company):
+    """A company's own terms page isn't TutorCruncher's, so role_type means nothing there."""
+    await db_conn.execute(sa_companies.update().values(options={'terms_link': 'https://terms.com/'}))
+    r = await cli.get(f'/{company.public_key}/options')
+    assert r.status == 200, await r.text()
+    assert (await r.json())['terms_link'] == 'https://terms.com/'
+
+
+async def test_options_no_terms_link(cli, db_conn, company):
+    """No terms link means no terms checkbox on the enquiry form - nothing to rewrite."""
+    r = await cli.get(f'/{company.public_key}/options')
+    assert r.status == 200, await r.text()
+    assert (await r.json())['terms_link'] is None


### PR DESCRIPTION
## Problem

The "terms and conditions" link next to the agreement checkbox on a Socket enquiry form opens a TutorCruncher page that renders nothing.

Reported by two agencies. Reproducible on the Dino Tutors demo site:

- `GET /9c79f14df986a1ec693c/options` returns `"terms_link": "https://app.dinotutors.com/view-branch-terms/3492/"`
- That URL renders an empty page
- `https://app.dinotutors.com/view-branch-terms/3492/?role_type=Client` renders the real terms

So the terms exist. Only the missing parameter breaks it.

## Cause

TutorCruncher split its terms and conditions per audience (Client, Tutor, Affiliate, Student) in July 2026 (TutorCruncher2 PR #16783). Its terms page now decides which set to show from a `role_type` query parameter, and resolves to nothing when the parameter is absent and the visitor is not logged in.

`terms_link` is a stored value. TutorCruncher pushes it to us when an integration is saved, and we serve it from `/<public_key>/options`. Every integration configured before that change still holds a URL with no `role_type`, already stored in our `companies.options`.

TutorCruncher2 issue: https://github.com/tutorcruncher/TutorCruncher2/issues/17376

## Why Client

Enquiry forms are Client enquiries. `process_enquiry` in TutorCruncher only ever matches or creates a `Client`, and calls `record_consent_given(client)` when the terms box is ticked. The audience is derived, not assumed.

## Why fix it here

The link value is fetched from `/options` at runtime on every page load, so correcting it server-side reaches every embedded form immediately, whatever version of `socket.js` the page loads. A fix in socket-frontend would only reach sites embedding `/socket/latest/socket.js`, not sites pinned to a version number.

## Change

`add_terms_link_role_type` in `tcsocket/app/views/company.py`, applied in `company_options`:

- adds `role_type=Client` to a TutorCruncher terms link that has no `role_type`
- leaves a link that already has a `role_type` untouched
- leaves a link that is not a TutorCruncher terms page untouched (agencies can point `terms_link` at their own website)
- preserves any other query parameters

Read path only. Nothing is written, and stored data is unchanged.

## Follow-up

TutorCruncher now adds `role_type` itself when an integration is saved, so once the stored values are backfilled on the TutorCruncher side this becomes a no-op and can be deleted.

## Testing

Five tests added to `tests/test_set_company.py` covering: link rewritten, existing `role_type` preserved, other query parameters preserved, non-TutorCruncher link untouched, no link at all.

**I could not run the suite locally.** This repo targets Python 3.9 and pins `aiopg` / `aioredis` / old `arq`; only Python 3.12 is available on my machine and those pins do not install on it. I verified the rewrite logic standalone against all the cases above, confirmed the files compile, and checked line length and import order against `setup.cfg`. The suite needs running by someone with a 3.9 toolchain before merge.

Note the Travis badge in the README points at `travis-ci.org`, which no longer exists, so CI may not run on this PR either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtaKcvP6cp5ZxLvYo8nxwU
